### PR TITLE
Feature/text decoration color

### DIFF
--- a/seed_styles/src/style/css_values.rs
+++ b/seed_styles/src/style/css_values.rs
@@ -597,6 +597,21 @@ pub enum CssTextDecoration {
 }
 
 #[derive(Display, Clone, Debug, CssStyleMacro)]
+#[display(fmt = "text-decoration-color: {};")]
+pub enum CssTextDecorationColor {
+    #[display(fmt = "rgba({},{},{},{})", _0, _1, _2, _3)]
+    Rgba(f64, f64, f64, f64),
+    #[display(fmt = "hsl({},{}%,{}%)", _0, _1, _2)]
+    Hsl(f64, f64, f64),
+    #[display(fmt = "hsla({},{}%,{}%,{})", _0, _1, _2, _3)]
+    Hsla(f64, f64, f64, f64), #[display(fmt = "#{:06x}", _0)]
+    Hex(i32),
+    StringValue(String),
+    #[display(fmt = "inherit")]
+    Inherit,
+}
+
+#[derive(Display, Clone, Debug, CssStyleMacro)]
 #[display(fmt = "text-indent: {};")]
 pub enum CssTextIndent {
     Length(ExactLength),
@@ -2568,7 +2583,6 @@ create_enums!([
     "TabSize",
     "TextAlignLast",
     "TextCombineUpright",
-    "TextDecorationColor",
     "TextDecorationLine",
     "TextDecorationStyle",
     "TextEmphasis",

--- a/seed_styles/src/style/theme.rs
+++ b/seed_styles/src/style/theme.rs
@@ -617,6 +617,19 @@ impl From<CssColor> for CssBackgroundColor {
     }
 }
 
+impl From<CssColor> for CssTextDecorationColor {
+    fn from(val: CssColor) -> Self {
+        match val {
+            CssColor::Rgba(r, g, b, a) => Self::Rgba(r, g, b, a),
+            CssColor::Hsl(h, s, l) => Self::Hsl(h, s, l),
+            CssColor::Hsla(h, s, l, a) => Self::Hsla(h, s, l, a),
+            CssColor::Hex(h) => Self::Hex(h),
+            CssColor::StringValue(val) => Self::StringValue(val),
+            CssColor::Inherit => Self::Inherit,
+        }
+    }
+}
+
 impl From<CssColor> for CssFill {
     fn from(val: CssColor) -> Self {
         match val {
@@ -1226,6 +1239,12 @@ generate_froms!([
         "ColorTheme",
         "CssColor",
         "CssBackgroundColor",
+        "colors_scale"
+    ),
+    (
+        "ColorTheme",
+        "CssColor",
+        "CssTextDecorationColor",
         "colors_scale"
     ),
     ("ColorTheme", "CssColor", "CssBorderColor", "colors_scale"),


### PR DESCRIPTION
I am adding the possibility to : 
- use s().text_decoration_color(COLOR)

Where COLOR is standard `seed_styles` CssColor, or Hex or Theme Color.

Tested locally with success.